### PR TITLE
Potential fix for code scanning alert no. 5: Uncontrolled data used in path expression

### DIFF
--- a/evaluation/geocoder_server.py
+++ b/evaluation/geocoder_server.py
@@ -5,6 +5,7 @@ Run with:  uv run python geocoder_server.py
 
 import io
 import os
+import re
 import time
 from pathlib import Path
 
@@ -103,11 +104,21 @@ class SaveQueryRequest(BaseModel):
 
 @app.post("/api/queries")
 def save_query(req: SaveQueryRequest):
-    safe = req.name.strip().replace(" ", "_")
-    if not safe:
+    raw_name = req.name.strip()
+    if not raw_name:
         raise HTTPException(400, "Name is empty")
+
+    safe = raw_name.replace(" ", "_")
+    if not re.fullmatch(r"[A-Za-z0-9_-]+", safe):
+        raise HTTPException(400, "Name contains invalid characters")
+
     filename = f"geocoder_query_{safe}.sql"
-    (QUERIES_DIR / filename).write_text(req.sql)
+    base_dir = QUERIES_DIR.resolve()
+    target = (base_dir / filename).resolve()
+    if base_dir not in target.parents:
+        raise HTTPException(400, "Invalid query path")
+
+    target.write_text(req.sql)
     return {"filename": filename}
 
 


### PR DESCRIPTION
Potential fix for [https://github.com/ajl2718/whereabouts/security/code-scanning/5](https://github.com/ajl2718/whereabouts/security/code-scanning/5)

Use strict filename validation plus canonical path containment checks before writing.

Best fix in this file:
1. Restrict `req.name` to a safe allowlist of characters (e.g., letters, digits, `_`, `-`), after trimming.
2. Build the target path and resolve it.
3. Verify the resolved target remains inside `QUERIES_DIR` (also resolved) before writing.
4. Reject invalid names/paths with `HTTPException(400, ...)`.

This preserves existing functionality (save named SQL files) while preventing traversal and absolute-path tricks.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
